### PR TITLE
Ca 119964 Lite agent changes to log more errors when WMI watches are received

### DIFF
--- a/proj/liteagent/LiteAgent.vcxproj
+++ b/proj/liteagent/LiteAgent.vcxproj
@@ -95,12 +95,13 @@
       <AdditionalDependencies>Powrprof.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <CustomBuildStep>
-      <Command>copy $(TargetPath) $(SolutionDir)\..\xeniface\x86
-</Command>
+      <Command>copy $(TargetPath) $(SolutionDir)\..\xeniface\$(PlatformTarget)
+copy $(TargetDir)LiteAgent.pdb $(SolutionDir)\..\xeniface\$(PlatformTarget)</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Copying output files</Message>
-      <Outputs>$(SolutionDir)\..\xeniface\x86\$(TargetFileName)</Outputs>
+      <Outputs>$(SolutionDir)\..\xeniface\$(PlatformTarget)$(TargetFileName);(SolutionDir)\..\xeniface\$(PlatformTarget)$(TargetName).pdb;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);$(TargetDir)$(TargetName).pdb</Inputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -119,11 +120,13 @@
       <AdditionalDependencies>Powrprof.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <CustomBuildStep>
-      <Command>copy $(TargetPath) $(SolutionDir)\..\xeniface\x64</Command>
+      <Command>copy $(TargetPath) $(SolutionDir)\..\xeniface\$(PlatformTarget)
+copy $(TargetDir)LiteAgent.pdb $(SolutionDir)\..\xeniface\$(PlatformTarget)</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Copying output files</Message>
-      <Outputs>$(SolutionDir)\..\xeniface\x64\$(TargetFileName)</Outputs>
+      <Outputs>$(SolutionDir)\..\xeniface\$(PlatformTarget)$(TargetFileName);(SolutionDir)\..\xeniface\$(PlatformTarget)$(TargetName).pdb;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);$(TargetDir)$(TargetName).pdb</Inputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -149,10 +152,10 @@
     </Link>
     <CustomBuildStep>
       <Message>Copying output files</Message>
-      <Command>copy $(TargetPath) $(SolutionDir)\..\xeniface\x86
-</Command>
-      <Outputs>$(SolutionDir)\..\xeniface\x86\$(TargetFileName)</Outputs>
-      <Inputs>$(TargetPath)</Inputs>
+      <Command>copy $(TargetPath) $(SolutionDir)\..\xeniface\$(PlatformTarget)
+copy $(TargetDir)LiteAgent.pdb $(SolutionDir)\..\xeniface\$(PlatformTarget)</Command>
+      <Outputs>$(SolutionDir)\..\xeniface\$(PlatformTarget)$(TargetFileName);(SolutionDir)\..\xeniface\$(PlatformTarget)$(TargetName).pdb;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);$(TargetDir)$(TargetName).pdb</Inputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -178,10 +181,10 @@
     </Link>
     <CustomBuildStep>
       <Message>Copying output files</Message>
-      <Command>
-copy $(TargetPath) $(SolutionDir)\..\xeniface\x64</Command>
-      <Outputs>$(SolutionDir)\..\xeniface\x64\$(TargetFileName)</Outputs>
-      <Inputs>$(TargetPath)</Inputs>
+      <Command>copy $(TargetPath) $(SolutionDir)\..\xeniface\$(PlatformTarget)
+copy $(TargetDir)LiteAgent.pdb $(SolutionDir)\..\xeniface\$(PlatformTarget)</Command>
+      <Outputs>$(SolutionDir)\..\xeniface\$(PlatformTarget)$(TargetFileName);(SolutionDir)\..\xeniface\$(PlatformTarget)$(TargetName).pdb;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);$(TargetDir)$(TargetName).pdb</Inputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/win32stubagent/WmiAccessor.cpp
+++ b/src/win32stubagent/WmiAccessor.cpp
@@ -1143,20 +1143,26 @@ int WmiSessionRemoveEntry(WMIAccessor** wmi,  void **sessionhandle,
     if (FAILED(methodExec(wmi,*session, L"RemoveValue", inMethodInst, &outMethodInst)))
         goto methodexecfailed;
 
-    if (outMethodInst==NULL)
-        goto sessionExec;
     outMethodInst->Release();
 
     err=0;
+    inMethodInst->Release();
+    VariantClear(&vpath);
+    return err;
 methodexecfailed:
+    OutputDebugString(__FUNCTION__ " MethodExecFailed");
 methodputfailed:
+    OutputDebugString(__FUNCTION__ " MethodPutFailed");
     inMethodInst->Release();
 
 sessionstart:
+    OutputDebugString(__FUNCTION__ " SessionStartFailed");
     VariantClear(&vpath);
 
 sessionExec:
+    OutputDebugString(__FUNCTION__ " SessionExecFailed");
 setvpath:
+    OutputDebugString(__FUNCTION__ " SetVpathFailed");
     return err; 
 }
 

--- a/src/win32stubagent/XService.cpp
+++ b/src/win32stubagent/XService.cpp
@@ -62,6 +62,7 @@ static ULONG WindowsVersion;
 static BOOL LegacyHal = FALSE;
 static HINSTANCE local_hinstance;
 
+HANDLE eventLog;
 #define SIZECHARS(x) (sizeof((x))/sizeof(TCHAR))
 
 // Internal routines
@@ -371,7 +372,6 @@ static BOOL maybeReboot(void *ctx)
     BOOL res;
     enum XShutdownType type;
     int cntr = 0;
-    HANDLE eventLog;
 
     XsLog("Check if we need to shutdown");
 
@@ -399,7 +399,6 @@ static BOOL maybeReboot(void *ctx)
        and it can't do any harm. */
     AcquireSystemShutdownPrivilege();
 
-    eventLog = RegisterEventSource(NULL, "xensvc");
     if (eventLog) {
         DWORD eventId;
 
@@ -419,7 +418,6 @@ static BOOL maybeReboot(void *ctx)
         }
         ReportEvent(eventLog, EVENTLOG_SUCCESS, 0, eventId, NULL, 0, 0,
                     NULL, NULL);
-        DeregisterEventSource(eventLog);
     }
 
     XsLog("Do the shutdown");
@@ -585,6 +583,9 @@ BOOL Run()
     }
     XsLog("Guest agent lite main loop starting");
 
+    if (eventLog == NULL)
+        XsLog("Event log was not initialised");
+
     memset(&features, 0, sizeof(features));
 
     HANDLE wmierrorEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
@@ -658,6 +659,10 @@ BOOL Run()
             }
             else if (event == suspendEvent)
             {
+                if (!ReportEvent(eventLog, EVENTLOG_SUCCESS, 0, EVENT_XENUSER_UNSUSPENDED, NULL, 0, 0,
+                            NULL, NULL)) {
+                    XsLog("Cannot send to event log %x",GetLastError());    
+                }
                 XsLog("Suspend event");
                 finishSuspend();
                 AdvertiseFeatures(&features);
@@ -666,6 +671,8 @@ BOOL Run()
             }
             else if (event == wmierrorEvent)
             {
+                ReportEvent(eventLog, EVENTLOG_SUCCESS, 0, EVENT_XENUSER_WMI, NULL, 0, 0,
+                            NULL, NULL);
                 break;
             }
             else
@@ -688,6 +695,8 @@ BOOL Run()
                 }
                 if (fail) {
                     XsLog("Resetting");
+                ReportEvent(eventLog, EVENTLOG_SUCCESS, 0, EVENT_XENUSER_UNEXPECTED, NULL, 0, 0,
+                            NULL, NULL);
                     break;
                 }
             }
@@ -746,6 +755,7 @@ bool ServiceInit()
 void WINAPI ServiceMain(int argc, char** argv)
 {
     // Perform common initialization
+    eventLog = RegisterEventSource(NULL, "xensvc");
     hServiceExitEvent = CreateEvent(NULL, false, false, NULL);
     if (hServiceExitEvent == NULL)
     {
@@ -774,6 +784,7 @@ void WINAPI ServiceMain(int argc, char** argv)
     
     XsLog("Guest agent service stopped");
     ShutdownXSAccessor();
+    DeregisterEventSource(eventLog);
     ServiceControlManagerUpdate(0, SERVICE_STOPPED);
     return;
 }

--- a/src/win32stubagent/XService.cpp
+++ b/src/win32stubagent/XService.cpp
@@ -85,6 +85,7 @@ void PrintError(const char *func, DWORD err)
         0,
         NULL);
     OutputDebugString((LPTSTR)lpMsgBuf);
+    XsLog("%s failed: %s (%x)", func, lpMsgBuf, err);
     XenstorePrintf("control/error", "%s failed: %s (%x)", func, lpMsgBuf, err);
     LocalFree(lpMsgBuf);
 }
@@ -695,8 +696,8 @@ BOOL Run()
                 }
                 if (fail) {
                     XsLog("Resetting");
-                ReportEvent(eventLog, EVENTLOG_SUCCESS, 0, EVENT_XENUSER_UNEXPECTED, NULL, 0, 0,
-                            NULL, NULL);
+                    ReportEvent(eventLog, EVENTLOG_SUCCESS, 0, EVENT_XENUSER_UNEXPECTED, NULL, 0, 0,
+                                NULL, NULL);
                     break;
                 }
             }

--- a/src/win32stubagent/messages.mc
+++ b/src/win32stubagent/messages.mc
@@ -32,3 +32,35 @@ SymbolicName=EVENT_XENUSER_S3
 Language=English
 The tools requested that the local VM enter power state S3.
 .
+
+MessageId=0x0005
+Facility=XenUser
+Severity=Informational
+SymbolicName=EVENT_XENUSER_WMI
+Language=English
+The tools noticed that WMI became non-functional.
+.
+
+MessageId=0x0006
+Facility=XenUser
+Severity=Informational
+SymbolicName=EVENT_XENUSER_STARTED
+Language=English
+The tools initiated.
+.
+
+MessageId=0x0007
+Facility=XenUser
+Severity=Informational
+SymbolicName=EVENT_XENUSER_UNSUSPENDED
+Language=English
+The tools returned from suspend.
+.
+
+MessageId=0x0008
+Facility=XenUser
+Severity=Informational
+SymbolicName=EVENT_XENUSER_UNEXPECTED
+Language=English
+The tools experienced an unexpected error.
+.


### PR DESCRIPTION
Lite agent changes to log more errors when WMI watches are received, and to add lite agent symbols to the xeniface tarfile.

Also fixes a bug which meant calls to Xenstore Remove over WMI were always thought to fail
