### PR TITLE
[CA-119964] Remove a null dereferece which causes an exception

### DIFF
--- a/src/win32stubagent/WmiAccessor.cpp
+++ b/src/win32stubagent/WmiAccessor.cpp
@@ -1143,7 +1143,8 @@ int WmiSessionRemoveEntry(WMIAccessor** wmi,  void **sessionhandle,
     if (FAILED(methodExec(wmi,*session, L"RemoveValue", inMethodInst, &outMethodInst)))
         goto methodexecfailed;
 
-    outMethodInst->Release();
+    if (outMethodInst != NULL)
+        outMethodInst->Release();
 
     err=0;
     inMethodInst->Release();

--- a/src/win32stubagent/XSAccessor.cpp
+++ b/src/win32stubagent/XSAccessor.cpp
@@ -210,6 +210,6 @@ XenstoreUnwatch(void *watch)
 void 
 XenstoreFree(void *tofree)
 {
-    return free(tofree);
+    return XsFree(tofree);
 }
 

--- a/src/win32stubagent/XService.cpp
+++ b/src/win32stubagent/XService.cpp
@@ -417,8 +417,6 @@ static BOOL maybeReboot(void *ctx)
             eventId = EVENT_XENUSER_S3;
             break;
         }
-        ReportEvent(eventLog, EVENTLOG_SUCCESS, 0, eventId, NULL, 0, 0,
-                    NULL, NULL);
     }
 
     XsLog("Do the shutdown");
@@ -781,7 +779,7 @@ void WINAPI ServiceMain(int argc, char** argv)
         __except(EXCEPTION_EXECUTE_HANDLER)
         {
             __try {
-                XsLog("Exception hit");
+                XsLog("Exception hit %x", GetExceptionCode());
             }
             __except(EXCEPTION_EXECUTE_HANDLER)
             {

--- a/src/xeniface.inf
+++ b/src/xeniface.inf
@@ -100,5 +100,5 @@ DiskId1 = "XenServer Tools for Virtual Machines"
 XenIfaceDevice.DeviceDesc = "XenServer Interface"
 xeniface.SVCDESC = "XenServer  Interface Device Driver"
 LITESVC_FLAGS= 0x00000800
-xenlite.SVCDESC= "XenSerrver Lite Guest Agent"
+xenlite.SVCDESC= "XenServer Lite Guest Agent"
 


### PR DESCRIPTION
Also:
Free a XenStore allocation using XSFree
Spell XenServer correctly
Remove the debug eventlog message on shutdown (messages on resume from
  suspend, wmi failure and unexpected error conditions remain as these
  will be useful for issue identification)

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
